### PR TITLE
Update payout calc method in staking pool

### DIFF
--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -41,7 +41,7 @@ contract StakingPool {
 
     // Add stakes
     function () external payable {
-        calclatePayoutWithMessage(msg.value);
+        calculatePayout();
         StakerInfo storage info = stakerInfo[msg.sender];
         // New staker
         if (info.stakes == 0) {
@@ -89,11 +89,7 @@ contract StakingPool {
     }
 
     function calculatePayout() private {
-        calclatePayoutWithMessage(0);
-    }
-
-    function calclatePayoutWithMessage(uint256 msgValue) private {
-        uint256 balance = address(this).balance - msgValue;
+        uint256 balance = address(this).balance - msg.value;
         uint256 dividend = getDividend(balance);
         if (dividend == 0) {
             return;

--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -30,7 +30,7 @@ contract StakingPool {
         maxStakers = _maxStakers;
     }
 
-    function totalStakerSize() public view returns (uint256) {
+    function poolSize() public view returns (uint256) {
         return stakers.length;
     }
 
@@ -84,6 +84,9 @@ contract StakingPool {
     }
 
     function calculateStakesWithDividend(address staker) public view returns (uint256) {
+        if (totalStakes == 0) {
+            return 0;
+        }
         uint256 dividend = getDividend(address(this).balance);
         uint256 stakerPayout = dividend.mul(MAX_BP - feeRateBp).div(MAX_BP);
         StakerInfo storage info = stakerInfo[staker];

--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -93,7 +93,10 @@ contract StakingPool {
 
     function estimateMinerReward() public view returns (uint256) {
         uint256 dividend = getDividend(address(this).balance);
-        return minerReward + dividend.mul(feeRateBp).div(MAX_BP);
+        if (stakers.length > 0) {
+            dividend = dividend.mul(feeRateBp).div(MAX_BP);
+        }
+        return minerReward.add(dividend);
     }
 
     function calculatePayout() private {

--- a/test/StakingPool.test.js
+++ b/test/StakingPool.test.js
@@ -154,4 +154,24 @@ contract('StakingPool', async (accounts) => {
     minerReward = await pool.estimateMinerReward();
     assert.equal(minerReward, toWei(20 / 2));
   });
+
+  it('should handle no staker case', async () => {
+    await forceSend(pool.address, toWei(10));
+    let minerReward = await pool.minerReward();
+    assert.equal(minerReward, toWei(0));
+    minerReward = await pool.estimateMinerReward();
+    assert.equal(minerReward, toWei(10));
+    // Now adding a new staker, while miner's fee shouldn't be affected.
+    await pool.sendTransaction(txGen(accounts[0], toWei(10)));
+    minerReward = await pool.minerReward();
+    assert.equal(minerReward, toWei(10));
+    minerReward = await pool.estimateMinerReward();
+    assert.equal(minerReward, toWei(10));
+    // Now, new rewards should be distributed evenly.
+    await forceSend(pool.address, toWei(4));
+    minerReward = await pool.estimateMinerReward();
+    assert.equal(minerReward, toWei(10 + (4 / 2)));
+    const stakes = await pool.calculateStakesWithDividend(accounts[0]);
+    assert.equal(stakes, toWei(10 + (4 / 2)));
+  });
 });


### PR DESCRIPTION
since `msg.value` can be accessed without `payable` keyword in private methods
also made `getDividend` a private function and added a `estimateMinerReward` method since the exact reward may not match