### PR TITLE
Add token registration switch

### DIFF
--- a/contracts/GeneralNativeTokenManager.sol
+++ b/contracts/GeneralNativeTokenManager.sol
@@ -31,14 +31,14 @@ contract GeneralNativeTokenManager {
     // Minimum amount of QKC to start functioning as gas reserve.
     uint128 public minGasReserveInit;
 
-    // Switch for token registration
+    // Switch for token registration.
     bool public registrationRequired;
     // Balance accounting: token ID -> token admin -> QKC balance.
     mapping (uint128 => mapping (address => uint256)) public gasReserveBalance;
     // Token ID -> token admin -> native token balance.
     mapping (uint128 => mapping (address => uint256)) public nativeTokenBalance;
     // Token ID -> registeredToken
-    mapping (uint256 => bool) public registeredTokens;
+    mapping (uint128 => bool) public registeredTokens;
 
     constructor (address _supervisor) public {
         supervisor = _supervisor;
@@ -75,13 +75,15 @@ contract GeneralNativeTokenManager {
     function registerToken() public payable {
         uint256 tokenId;
 
+        // Call precompiled contract to query current native token id
+        // as a proof of the existence of this token
         /* solium-disable-next-line */
         assembly {
            if iszero(call(not(0), 0x514b430001, 0, 0, 0, tokenId, 0x20)){
                revert(0, 0)
            }
         }
-        registeredTokens[tokenId] = true;
+        registeredTokens[uint128(tokenId)] = true;
     }
 
     function proposeNewExchangeRate(

--- a/contracts/GeneralNativeTokenManager.sol
+++ b/contracts/GeneralNativeTokenManager.sol
@@ -76,13 +76,14 @@ contract GeneralNativeTokenManager {
         uint256 tokenId;
 
         // Call precompiled contract to query current native token id
-        // as a proof of the existence of this token
+        // as a proof of the existence of this token.
         /* solium-disable-next-line */
         assembly {
            if iszero(call(not(0), 0x514b430001, 0, 0, 0, tokenId, 0x20)){
                revert(0, 0)
            }
         }
+        // Token ID is guaranteed to be less than maximum of uint128.
         registeredTokens[uint128(tokenId)] = true;
     }
 

--- a/contracts/GeneralNativeTokenManager.sol
+++ b/contracts/GeneralNativeTokenManager.sol
@@ -31,13 +31,18 @@ contract GeneralNativeTokenManager {
     // Minimum amount of QKC to start functioning as gas reserve.
     uint128 public minGasReserveInit;
 
+    // Switch for token registration
+    bool public registrationRequired;
     // Balance accounting: token ID -> token admin -> QKC balance.
     mapping (uint128 => mapping (address => uint256)) public gasReserveBalance;
     // Token ID -> token admin -> native token balance.
     mapping (uint128 => mapping (address => uint256)) public nativeTokenBalance;
+    // Token ID -> registeredToken
+    mapping (uint256 => bool) public registeredTokens;
 
     constructor (address _supervisor) public {
         supervisor = _supervisor;
+        registrationRequired = true;
     }
 
     modifier onlySupervisor {
@@ -63,6 +68,22 @@ contract GeneralNativeTokenManager {
         supervisor = newSupervisor;
     }
 
+    function requireTokenRegistration(bool req) public onlySupervisor {
+        registrationRequired = req;
+    }
+
+    function registerToken() public payable {
+        uint256 tokenId;
+
+        /* solium-disable-next-line */
+        assembly {
+           if iszero(call(not(0), 0x514b430001, 0, 0, 0, tokenId, 0x20)){
+               revert(0, 0)
+           }
+        }
+        registeredTokens[tokenId] = true;
+    }
+
     function proposeNewExchangeRate(
         uint128 tokenId,
         uint128 rateNumerator,
@@ -70,6 +91,9 @@ contract GeneralNativeTokenManager {
     )
         public payable
     {
+        if (registrationRequired) {
+            require(registeredTokens[tokenId], "Token ID does not exist.");
+        }
         require(0 < rateNumerator, "Value should be non-zero.");
         require(0 < rateDenominator, "Value should be non-zero.");
         require(
@@ -102,7 +126,7 @@ contract GeneralNativeTokenManager {
     }
 
     function depositGasReserve(uint128 tokenId) public payable {
-        require(gasReserveBalance[tokenId][msg.sender] > 0, "should be an exited token");
+        require(gasReserveBalance[tokenId][msg.sender] > 0, "should be an existed token");
         uint256 newBalance = gasReserveBalance[tokenId][msg.sender] + msg.value;
         require(newBalance >= msg.value, "should be a valid term");
         gasReserveBalance[tokenId][msg.sender] = newBalance;
@@ -117,7 +141,10 @@ contract GeneralNativeTokenManager {
             msg.sender == gasReserves[tokenId].admin,
             "Only admin can set refund rate."
         );
-        require(10 <= refundPercentage && refundPercentage <= 100, "Should be between 0 and 100%.");
+        require(
+            10 <= refundPercentage && refundPercentage <= 100,
+            "Refund pertentage should be between 10 and 100."
+        );
         gasReserves[tokenId].refundPercentage = refundPercentage;
     }
 

--- a/contracts/GeneralNativeTokenManager.sol
+++ b/contracts/GeneralNativeTokenManager.sol
@@ -37,7 +37,7 @@ contract GeneralNativeTokenManager {
     mapping (uint128 => mapping (address => uint256)) public gasReserveBalance;
     // Token ID -> token admin -> native token balance.
     mapping (uint128 => mapping (address => uint256)) public nativeTokenBalance;
-    // Token ID -> registeredToken
+    // Token ID -> token registered or not.
     mapping (uint128 => bool) public registeredTokens;
 
     constructor (address _supervisor) public {

--- a/test/GeneralNativeTokenManager.test.js
+++ b/test/GeneralNativeTokenManager.test.js
@@ -23,6 +23,11 @@ contract('GeneralNativeTokenManager', async (accounts) => {
     // Add more QKC fail if invalid tokenId.
     await manager.depositGasReserve(123, { from: accounts[0], value: toWei(2) })
       .should.be.rejectedWith(revertError);
+    // Non-existed token can not be proposed exchange rate.
+    await manager.proposeNewExchangeRate(123, 1, 1, { from: accounts[0], value: toWei(2) })
+      .should.be.rejectedWith(revertError);
+    // The supervisor turn off the token registration switch
+    await manager.requireTokenRegistration(false);
     // First time adding reserve should succeed.
     await manager.proposeNewExchangeRate(123, 1, 1, { from: accounts[0], value: toWei(2) });
     // Check the ratio is correct.

--- a/test/GeneralNativeTokenManager.test.js
+++ b/test/GeneralNativeTokenManager.test.js
@@ -26,7 +26,7 @@ contract('GeneralNativeTokenManager', async (accounts) => {
     // Non-existed token can not be proposed exchange rate.
     await manager.proposeNewExchangeRate(123, 1, 1, { from: accounts[0], value: toWei(2) })
       .should.be.rejectedWith(revertError);
-    // The supervisor turn off the token registration switch
+    // The supervisor turn off the token registration switch.
     await manager.requireTokenRegistration(false);
     // First time adding reserve should succeed.
     await manager.proposeNewExchangeRate(123, 1, 1, { from: accounts[0], value: toWei(2) });
@@ -69,7 +69,7 @@ contract('GeneralNativeTokenManager', async (accounts) => {
       .should.be.rejectedWith(revertError);
     // Success.
     await manager.setRefundPercentage(123, 66, { from: accounts[1] });
-    // Refund rate should be > 0 && refund rate <= 100
+    // Refund rate should be in the range between 10% and 100%.
     await manager.setRefundPercentage(123, 101, { from: accounts[1] })
       .should.be.rejectedWith(revertError);
     const refundPercentage = (await manager.gasReserves(123))[1];
@@ -80,7 +80,7 @@ contract('GeneralNativeTokenManager', async (accounts) => {
       .should.be.rejectedWith(revertError);
     await manager.proposeNewExchangeRate(123, 1, 0, { from: accounts[0], value: toWei(10) })
       .should.be.rejectedWith(revertError);
-    // Requires ratio * 21000 <= minGasReserve
+    // Requires ratio * 21000 <= minGasReserve.
     await manager.proposeNewExchangeRate(123, toWei(1), 1, { from: accounts[0], value: toWei(10) })
       .should.be.rejectedWith(revertError);
 


### PR DESCRIPTION
User must register the token before proposing its exchange rate to make sure the token exists.