### PR TITLE
Fix package in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: install-npm
-          command: test ! -d node_modules && npm ci
+          command: if [ ! -d node_modules ]; then npm ci; fi
       - run:
           name: lint
           command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: install-npm
-          command: rm package-lock.json && npm install
+          command: test ! -d node_modules && npm ci
       - run:
           name: lint
           command: npm run lint


### PR DESCRIPTION
1. when package cache is available, skip installing
2. when package cache gets out-dated and deleted, run `npm ci` to install packages according to the lock file
3. if `package.json` updates, package cache becomes outdated, so will run `npm ci` again, therefore **we always need to keep package lock file in sync with the updated `package.json` when submitting a PR**