### PR TITLE
fix an issue that gas reserved could be smaller than maintain

### DIFF
--- a/contracts/GeneralNativeTokenManager.sol
+++ b/contracts/GeneralNativeTokenManager.sol
@@ -209,10 +209,6 @@ contract GeneralNativeTokenManager {
             "Avoid uint256 overflow."
         );
         require(
-            minGasReserveMaintain <= gasReserveBalance[tokenId][admin],
-            "Should have reserve amount greater than minimum."
-        );
-        require(
             qkcGasAmount <= gasReserveBalance[tokenId][admin],
             "Should have enough reserves to pay."
         );


### PR DESCRIPTION
Even the current gas reserved is smaller than maintain, the user may still pay tx fee using another native token as long as the gas reserved is sufficient to pay the fee in QKC.