### PR TITLE
[auction] Burn QKC after end & [gas] Caller in cstor

### DIFF
--- a/contracts/GeneralNativeTokenManager.sol
+++ b/contracts/GeneralNativeTokenManager.sol
@@ -40,8 +40,14 @@ contract GeneralNativeTokenManager {
     // A flag to freeze current gas reserve to prepare for migration.
     bool public frozen = false;
 
-    constructor (address _supervisor) public {
+    constructor (address _supervisor, address _payGasCaller) public {
         supervisor = _supervisor;
+        // If caller not specified, should be the contract address itself.
+        if (_payGasCaller == address(0)) {
+            payGasCaller = address(this);
+        } else {
+            payGasCaller = _payGasCaller;
+        }
         registrationRequired = true;
     }
 
@@ -61,11 +67,6 @@ contract GeneralNativeTokenManager {
     {
         minGasReserveMaintain = _minGasReserveMaintain;
         minGasReserveInit = _minGasReserveInit;
-    }
-
-    // Should only be for testing, otherwise no incentive to change.
-    function setCaller(address _payGasCaller) public onlySupervisor {
-        payGasCaller = _payGasCaller;
     }
 
     function updateSupervisor(address newSupervisor) public onlySupervisor {

--- a/contracts/GeneralNativeTokenManager.sol
+++ b/contracts/GeneralNativeTokenManager.sol
@@ -12,9 +12,9 @@ contract GeneralNativeTokenManager {
     }
 
     // Required caller for using native token to pay gas in QKC.
-    // Defaulting to the contract address itself will make sure the invocation can
-    // only be done in consensus, while allowing mock for unit testing.
-    address public payGasCaller = address(this);
+    // Setting to the contract address itself will make sure the invocation can
+    // only be done in consensus, while allowing mock for unit testing. Configured in cstor.
+    address public payGasCaller;
 
     // Contract admin in early stage. Capabilities are limited and may be unset.
     address public supervisor;

--- a/contracts/NonReservedNativeTokenManager.sol
+++ b/contracts/NonReservedNativeTokenManager.sol
@@ -234,7 +234,7 @@ contract NonReservedNativeTokenManager {
 
         balances[_auction.highestBid.bidder] -= _auction.highestBid.newTokenPrice;
         // Burn the actual QKC.
-        address(0x2).transfer(_auction.highestBid.newTokenPrice);
+        address(0x0).transfer(_auction.highestBid.newTokenPrice);
 
         nativeTokens[_auction.highestBid.tokenId].owner = _auction.highestBid.bidder;
         nativeTokens[_auction.highestBid.tokenId].createAt = uint64(now);

--- a/contracts/NonReservedNativeTokenManager.sol
+++ b/contracts/NonReservedNativeTokenManager.sol
@@ -233,6 +233,9 @@ contract NonReservedNativeTokenManager {
         assert (balances[_auction.highestBid.bidder] >= _auction.highestBid.newTokenPrice);
 
         balances[_auction.highestBid.bidder] -= _auction.highestBid.newTokenPrice;
+        // Burn the actual QKC.
+        address(0x2).transfer(_auction.highestBid.newTokenPrice);
+
         nativeTokens[_auction.highestBid.tokenId].owner = _auction.highestBid.bidder;
         nativeTokens[_auction.highestBid.tokenId].createAt = uint64(now);
         emit AuctionEnded(_auction.highestBid.bidder, _auction.highestBid.tokenId);

--- a/test/GeneralNativeTokenManager.test.js
+++ b/test/GeneralNativeTokenManager.test.js
@@ -11,7 +11,8 @@ contract('GeneralNativeTokenManager', async (accounts) => {
   let manager;
 
   beforeEach(async () => {
-    manager = await GeneralNativeTokenManager.new(accounts[0]);
+    // Use account 3 as the caller for debugging purposes.
+    manager = await GeneralNativeTokenManager.new(accounts[0], accounts[3]);
     manager.setMinGasReserve(toWei(2), toWei(2), { from: accounts[0] });
   });
 
@@ -85,7 +86,6 @@ contract('GeneralNativeTokenManager', async (accounts) => {
       .should.be.rejectedWith(revertError);
 
     // Test converting native tokens to QKC as gas.
-    await manager.setCaller(accounts[3], { from: accounts[0] });
     await manager.payAsGas(123, toWei(7), 1, { from: accounts[3] });
     // Check the total deposit. toWei(22) - toWei(7) * 3 = toWei(1).
     assert.equal(await manager.gasReserveBalance(123, accounts[1]), toWei(1));
@@ -127,7 +127,6 @@ contract('GeneralNativeTokenManager', async (accounts) => {
     await manager.proposeNewExchangeRate(123, 1, 2, { from: accounts[1], value: toWei(10) })
       .should.be.rejectedWith(revertError);
 
-    await manager.setCaller(accounts[3], { from: accounts[0] });
     await manager.payAsGas(123, toWei(7), 1, { from: accounts[3] });
     assert.equal(await manager.gasReserveBalance(123, accounts[0]), toWei(8));
 
@@ -150,7 +149,6 @@ contract('GeneralNativeTokenManager', async (accounts) => {
       .should.be.rejectedWith(revertError);
     // Paying as gas should succeed.
     const caller = accounts[3];
-    await manager.setCaller(caller, { from: accounts[0] });
     await manager.payAsGas(123, toWei(1), 1, { from: caller });
     assert.equal(await manager.gasReserveBalance(123, accounts[0]), toWei(5 - 1));
 


### PR DESCRIPTION
1. actually burns QKC after auction ends, in case in the future we want accounting data so the contract balance and the internal state match each other
2. sets pay gas caller in constructor to simplify testing but avoids security loopholes in case a supervisor is compromised (as we disallow changing pay gas caller)